### PR TITLE
Add toggling functionality to left bar in workshop

### DIFF
--- a/src/uxbox/workspace/actions.cljs
+++ b/src/uxbox/workspace/actions.cljs
@@ -11,9 +11,9 @@
   [setting-box]
   (pubsub/publish! [:close-setting-box setting-box]))
 
-(defn open-setting-box
+(defn toggle-setting-box
   [setting-box]
-  (pubsub/publish! [:open-setting-box setting-box]))
+  (pubsub/publish! [:toggle-setting-box setting-box]))
 
 (defn set-tool
   [tool]
@@ -72,6 +72,14 @@
    (if (= setting-box :layers)
      (update state :open-setting-boxes #(conj %1 setting-box))
      (update state :open-setting-boxes #(clojure.set/intersection (conj %1 setting-box) #{:layers setting-box})))))
+
+(pubsub/register-event
+ :toggle-setting-box
+ (fn [state setting-box]
+   (let [setting-boxes (:open-setting-boxes state)]
+     (if (contains? setting-boxes setting-box)
+       (pubsub/publish! [:close-setting-box setting-box])
+       (pubsub/publish! [:open-setting-box setting-box])))))
 
 (pubsub/register-transition
  :set-tool

--- a/src/uxbox/workspace/views.cljs
+++ b/src/uxbox/workspace/views.cljs
@@ -352,13 +352,13 @@
     [:div.tool-bar-inside
      [:ul.main-tools
       [:li.tooltip {:alt "Shapes (Ctrl + Shift + F)" :class (if (:tools (:open-setting-boxes @db)) "current" "")
-            :on-click #(actions/open-setting-box :tools)} icons/shapes]
+            :on-click #(actions/toggle-setting-box :tools)} icons/shapes]
       [:li.tooltip {:alt "Components (Ctrl + Shift + C)" :class (if (:components (:open-setting-boxes @db)) "current" "")
-            :on-click #(actions/open-setting-box :components)} icons/puzzle]
+            :on-click #(actions/toggle-setting-box :components)} icons/puzzle]
       [:li.tooltip {:alt "Icons (Ctrl + Shift + I)" :class (if (:figures (:open-setting-boxes @db)) "current" "")
-            :on-click #(actions/open-setting-box :figures)} icons/icon-set]
+            :on-click #(actions/toggle-setting-box :figures)} icons/icon-set]
       [:li.tooltip {:alt "Elements (Ctrl + Shift + L)" :class (if (:layers (:open-setting-boxes @db)) "current" "")
-            :on-click #(actions/open-setting-box :layers)} icons/layers]
+            :on-click #(actions/toggle-setting-box :layers)} icons/layers]
       [:li.tooltip {:alt "Feedback (Ctrl + Shift + M)"}
        icons/chat]]]])
 


### PR DESCRIPTION
This PR adds the option of "closing" the right panel from clicking the icons in the left bar.
With this change the code is a bit cleaner, because "open" and "close" become "toggle".

Any thoughts? @elhombretecla @dialelo @niwinz 
