### PR TITLE
Improve and document gulpjs usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ user> (cljs-repl)
 After that, a figwheel message will appear and the prompt will change to `cljs.user>`. We can now evaluate ClojureScript in the
 browser from the REPL.
 
+### Static resources generation
+
+The project's static resources are processed using [gulp](http://gulpjs.com/). First of all, install the npm dependencies running:
+
+```
+npm install
+```
+
+To start watching the files and process them with each change, run:
+
+```
+npm run watch
+```
+
+To process the resources just once, run:
+
+```
+npm run dist
+```
+
 ### Testing
 
 For running the tests from a shell, run the following command:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "main": "app.js",
   "author": "Uxbox",
   "license": "BSD",
+  "scripts": {
+    "watch": "gulp",
+    "dist": "gulp dist"
+  },
   "dependencies": {
     "gulp": "~3.8.11",
     "gulp-clean": "^0.3.1",


### PR DESCRIPTION
To avoid needing gulp installed as a global dependency, two scripts have
been created in the package.json file to manage gulp common tasks, watch
and dist.

The usage of this scripts has been documented in the README.md file.
